### PR TITLE
Fixed Vignette Build Issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     readxl,
     ggplot2,
     cowplot
-Suggests: knitr
+Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
 License: Apache License 2.0
 LazyData: true

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -2,10 +2,11 @@
 title: "Calibration vignette"
 author: "Edward Wallace"
 date: "2 Feb 2019"
-output:
-  html_document:
-    toc: true
-    toc_depth: 2
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Calibration}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
 ---
 
 
@@ -43,7 +44,7 @@ These probes have sensible standard curves, amplification curves, melt curves. I
 
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -2,10 +2,11 @@
 title: "Multifactorial multi-plate qPCR analysis"
 author: "Edward Wallace"
 date: "June 2018"
-output:
-  html_document:
-    toc: true
-    toc_depth: 2
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Multifactorial}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
 ---
 
 # Plan
@@ -34,7 +35,7 @@ Test 6 conditions. That's 3 transcriptional inhibitors (no drug control, 150ug/m
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)


### PR DESCRIPTION
vignette("multifactor_vignette") and vignette("calibration_vignette") now work

Originally, R was not building the vignettes correctly so I've added a couple of lines of code to the YAML headers of both vignette files. Now you can see the correctly formed vignette files. Also made sure the code is printed alongside the diagrams. 

If you're happy then I suggest merging this branch with base branch!