### PR TITLE
Revert "Fixed Vignette Build Issue"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     readxl,
     ggplot2,
     cowplot
-Suggests: knitr, rmarkdown
+Suggests: knitr
 VignetteBuilder: knitr
 License: Apache License 2.0
 LazyData: true

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -2,11 +2,10 @@
 title: "Calibration vignette"
 author: "Edward Wallace"
 date: "2 Feb 2019"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Calibration}
-  %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
 ---
 
 
@@ -44,7 +43,7 @@ These probes have sensible standard curves, amplification curves, melt curves. I
 
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -2,11 +2,10 @@
 title: "Multifactorial multi-plate qPCR analysis"
 author: "Edward Wallace"
 date: "June 2018"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Multifactorial}
-  %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
 ---
 
 # Plan
@@ -35,7 +34,7 @@ Test 6 conditions. That's 3 transcriptional inhibitors (no drug control, 150ug/m
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)


### PR DESCRIPTION
Reverts ewallace/tidyqpcr#8, because vignette issues weren't fully fixed.