### PR TITLE
Fix vignettes again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,12 @@ Imports:
     tibble,
     tidyr,
     dplyr,
-    reshape2,
     readr,
-    readxl,
-    ggplot2,
+    ggplot2
+Suggests: knitr, 
+    rmarkdown, 
+    tidyverse,
     cowplot
-Suggests: knitr, rmarkdown, tidyverse
 VignetteBuilder: knitr
 License: Apache License 2.0
 LazyData: true

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,11 @@
 # basic NAMESPACE that exports everything
 # Ideally would be replaced by roxygen2
 
+importFrom("stats", "median", "predict", "smooth.spline")
+importFrom("magrittr", "%>%")
+importFrom("tibble", "tibble", "as_tibble")
+importFrom("dplyr", "sym")
+
 export(scale_x_log2nice)
 export(scale_x_log10nice)
 export(scale_y_log2nice)

--- a/R/amp_melt_curve_functions.R
+++ b/R/amp_melt_curve_functions.R
@@ -28,12 +28,12 @@
 debaseline <- function(plateamp,maxcycle=10) {
     baseline <- 
         plateamp %>%
-        group_by(Well) %>%
-        filter(Program == 2, Cycle <= maxcycle) %>%
-        summarize(Base = median(Fluor))
+        dplyr::group_by(Well) %>%
+        dplyr::filter(Program == 2, Cycle <= maxcycle) %>%
+        dplyr::summarize(Base = median(Fluor))
     plateamp %>% 
-        left_join(baseline) %>%
-        mutate(Signal=Fluor-Base)
+        dplyr::left_join(baseline) %>%
+        dplyr::mutate(Signal=Fluor-Base)
         
 }
 
@@ -69,10 +69,11 @@ getdRdT <- function(TT,RR,method=c("spline","diff"),...) {
 #' @family melt_curve_functions
 getdRdTall <- function(platemelt) {
     platemelt %>%
-        arrange(Well,Temperature) %>%
+        dplyr::arrange(Well,Temperature) %>%
         # @ewallace: doesn't group by plate, only by well,
         # so will fail strangely if used on data from multiple plates
-        group_by(Well) %>% 
-        mutate(dRdT=getdRdT(Temperature,Fluor)) %>%
-        ungroup()
+        dplyr::group_by(Well) %>% 
+        dplyr::mutate(dRdT=getdRdT(Temperature,Fluor)) %>%
+        dplyr::ungroup() %>%
+        return()
 }

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -193,29 +193,31 @@ label_plate_rowcol <- function(plate,rowkey=NULL,colkey=NULL) {
 }
 
 
-#' Display plate plan with Sample and Probe names
+#' Display plate plan with Sample, Probe, Type per Well
 #'
 #' @param plate tibble with variables WellC, WellR, Sample, Probe, Type. 
 #'   Output from label_plate_rowcol. 
 #'
 #' @return ggplot object; major output is to plot it
 #'
-#' @examples TBD
+#' @examples # !Needs a labeled example from label_plate_rowcol...
 #' @family plate creation functions
 display_plate <- function(plate) {
-    ggplot(data=plate,aes(x=factor(WellC),
-                          y=factor(WellR,levels=rev(LETTERS)))) +
-        geom_tile(aes(fill=Probe),alpha=0.3) +
-        geom_text(aes(label=paste(Probe,Sample,Type,sep="\n")),size=2.5,lineheight=1) +
-        scale_x_discrete(expand=c(0,0)) +
-        scale_y_discrete(expand=c(0,0)) +
-        coord_equal() +
-        theme_void() + 
-        theme(axis.text=element_text(angle=0),
-              panel.grid.major=element_blank(),
-              legend.position="none",
-              plot.margin=unit(rep(0.01,4),"npc"),
-              panel.border = element_blank())
+    ggplot2::ggplot(data=plate,
+                    aes(x=factor(WellC),
+                        y=factor(WellR,levels=rev(LETTERS)))) +
+        ggplot2::geom_tile(aes(fill=Probe),alpha=0.3) +
+        ggplot2::geom_text(aes(label=paste(Probe,Sample,Type,sep="\n")),
+                           size=2.5,lineheight=1) +
+        ggplot2::scale_x_discrete(expand=c(0,0)) +
+        ggplot2::scale_y_discrete(expand=c(0,0)) +
+        ggplot2::coord_equal() +
+        ggplot2::theme_void() + 
+        ggplot2::theme(axis.text=ggplot2::element_text(angle=0),
+                       panel.grid.major=ggplot2::element_blank(),
+                       legend.position="none",
+                       plot.margin=grid::unit(rep(0.01,4),"npc"),
+                       panel.border=ggplot2::element_blank())
 }
 
 

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -15,7 +15,7 @@
 create_blank_plate <- function(WellR=LETTERS[1:16],WellC=1:24) {
     plate <- tidyr::crossing(WellR=factor(WellR),
                          WellC=factor(WellC)) %>%
-        tibble::as_tibble() %>%
+        as_tibble() %>%
         tidyr::unite(Well,WellR,WellC,sep="",remove=FALSE)
     return(plate)
 }
@@ -39,8 +39,8 @@ create_colkey_6in24 <- function(...) {
     if( !missing(...) ) {
         pieces6 <- list(...) %>% as_tibble()
         stopifnot(nrow(pieces6) == 6)
-        pieces24 <- bind_rows(pieces6,pieces6,pieces6,pieces6)
-        colkey <- bind_cols(colkey, pieces24)
+        pieces24 <- dplyr::bind_rows(pieces6,pieces6,pieces6,pieces6)
+        colkey <- dplyr::bind_cols(colkey, pieces24)
     }
     return(colkey)
 }
@@ -132,8 +132,8 @@ create_rowkey_4in16 <- function(...) {
     if( !missing(...) ) {
         pieces4 <- list(...) %>% as_tibble()
         stopifnot(nrow(pieces4) == 4)
-        pieces16 <- bind_rows(pieces4,pieces4,pieces4,pieces4)
-        rowkey <- bind_cols(rowkey, pieces16)
+        pieces16 <- dplyr::bind_rows(pieces4,pieces4,pieces4,pieces4)
+        rowkey <- dplyr::bind_cols(rowkey, pieces16)
     }
     return(rowkey)
 }
@@ -156,8 +156,8 @@ create_rowkey_8in16_plain <- function(...) {
     if( !missing(...) ) {
         pieces8 <- list(...) %>% as_tibble()
         stopifnot(nrow(pieces8) == 8)
-        pieces16 <- bind_rows(pieces8,pieces8)
-        rowkey <- bind_cols(rowkey, pieces16)
+        pieces16 <- dplyr::bind_rows(pieces8,pieces8)
+        rowkey <- dplyr::bind_cols(rowkey, pieces16)
     }
     return(rowkey)
 }
@@ -256,12 +256,12 @@ getNormCt <- function(ct_df,value="Ct",normProbes="ALG9",probename="Probe") {
 #' 
 normalizeqPCR <- function(ct_df,value="Ct",normProbes="ALG9",probename="Probe") {
     ct_df %>%
-        group_by(Sample) %>%
-        do(getNormCt(.,value,normProbes,probename)) %>%
-        ungroup() %>%
-        mutate(.Value = !!sym(value), # a tidyeval trick
+        dplyr::group_by(Sample) %>%
+        dplyr::do(getNormCt(.,value,normProbes,probename)) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(.Value = !!sym(value), # a tidyeval trick
                Value.norm = .Value - norm.by, 
                Value.normexp =2^-Value.norm ) %>%
-        select(-.Value) %>%
+        dplyr::select(-.Value) %>%
         return()
 }

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -8,23 +8,27 @@
 #' @param omag orders of magnitude or fold-changes for axis labels, 
 #' usually an integer sequence.
 #' @param scilabels display labels in scientific format, e.g. \eqn{10^2} vs 100.
-#' @return a ggproto object as output by continuous_scale. 
+#' @param ... other arguments to continuous_scale().
+#' @return a ggproto object as output by continuous_scale(). 
 #' @name log_plot_helpers
 NULL
 
 #' @describeIn log_plot_helpers plot x axis on log2-scale with nice defaults
-scale_x_log2nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
+scale_x_log2nice <- function(name=ggplot2::waiver(),
+                             omag=seq(-10,10),
+                             scilabels=FALSE,
+                             ...) {
     breaks2 <- 2^omag
     if (scilabels) {
         labels2 <- paste("2^{",omag,"}",sep="")
     } else {
         labels2 <- breaks2
     }
-    scale_x_log10(name,breaks=breaks2,labels=parse(text=labels2),...)
+    ggplot2::scale_x_log10(name,breaks=breaks2,labels=parse(text=labels2),...)
 }
 
 #' @describeIn log_plot_helpers plot x axis on log10-scale with nice defaults
-scale_x_log10nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
+scale_x_log10nice <- function(name=ggplot2::waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
     # @ewallace: ideally would also create minor breaks from 2:9.
     breaks10 <- 10^omag
     if (scilabels) {
@@ -32,22 +36,22 @@ scale_x_log10nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...
     } else {
         labels10 <- breaks10
     }
-    scale_x_log10(name,breaks=breaks10,labels=parse(text=labels10),...)
+    ggplot2::scale_x_log10(name,breaks=breaks10,labels=parse(text=labels10),...)
 }
 
 #' @describeIn log_plot_helpers plot y axis on log2-scale with nice defaults
-scale_y_log2nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
+scale_y_log2nice <- function(name=ggplot2::waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
     breaks2 <- 2^omag
     if (scilabels) {
         labels2 <- paste("2^{",omag,"}",sep="")
     } else {
         labels2 <- breaks2
     }
-    scale_y_log10(name,breaks=breaks2,labels=parse(text=labels2),...)
+    ggplot2::scale_y_log10(name,breaks=breaks2,labels=parse(text=labels2),...)
 }
 
 #' @describeIn log_plot_helpers plot y axis on log10-scale with nice defaults
-scale_y_log10nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
+scale_y_log10nice <- function(name=ggplot2::waiver(),omag=seq(-10,10),scilabels=FALSE,...) {
     # @ewallace: ideally would also create minor breaks from 2:9.
     breaks10 <- 10^omag
     if (scilabels) {
@@ -55,7 +59,7 @@ scale_y_log10nice <- function(name=waiver(),omag=seq(-10,10),scilabels=FALSE,...
     } else {
         labels10 <- breaks10
     }
-    scale_y_log10(name,breaks=breaks10,labels=parse(text=labels10),...)
+    ggplot2::scale_y_log10(name,breaks=breaks10,labels=parse(text=labels10),...)
 }
 
 #' @describeIn log_plot_helpers plot x AND y axes on log10-scale with nice defaults

--- a/man/display_plate.Rd
+++ b/man/display_plate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/plate_functions.R
 \name{display_plate}
 \alias{display_plate}
-\title{Display plate plan with Sample and Probe names}
+\title{Display plate plan with Sample, Probe, Type per Well}
 \usage{
 display_plate(plate)
 }
@@ -14,10 +14,10 @@ Output from label_plate_rowcol.}
 ggplot object; major output is to plot it
 }
 \description{
-Display plate plan with Sample and Probe names
+Display plate plan with Sample, Probe, Type per Well
 }
 \examples{
-TBD
+# !Needs a labeled example from label_plate_rowcol...
 }
 \seealso{
 Other plate creation functions: \code{\link{create_blank_plate}},

--- a/man/log_plot_helpers.Rd
+++ b/man/log_plot_helpers.Rd
@@ -9,16 +9,16 @@
 \alias{scale_loglog10}
 \title{Nice tick labels for logarithmic axes in ggplot2.}
 \usage{
-scale_x_log2nice(name = waiver(), omag = seq(-10, 10),
+scale_x_log2nice(name = ggplot2::waiver(), omag = seq(-10, 10),
   scilabels = FALSE, ...)
 
-scale_x_log10nice(name = waiver(), omag = seq(-10, 10),
+scale_x_log10nice(name = ggplot2::waiver(), omag = seq(-10, 10),
   scilabels = FALSE, ...)
 
-scale_y_log2nice(name = waiver(), omag = seq(-10, 10),
+scale_y_log2nice(name = ggplot2::waiver(), omag = seq(-10, 10),
   scilabels = FALSE, ...)
 
-scale_y_log10nice(name = waiver(), omag = seq(-10, 10),
+scale_y_log10nice(name = ggplot2::waiver(), omag = seq(-10, 10),
   scilabels = FALSE, ...)
 
 scale_loglog10(...)
@@ -30,9 +30,11 @@ scale_loglog10(...)
 usually an integer sequence.}
 
 \item{scilabels}{display labels in scientific format, e.g. \eqn{10^2} vs 100.}
+
+\item{...}{other arguments to continuous_scale().}
 }
 \value{
-a ggproto object as output by continuous_scale.
+a ggproto object as output by continuous_scale().
 }
 \description{
 These functions are wrappers for scale_x_log10, etc., that specify

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -1,11 +1,12 @@
 ---
 title: "Calibration vignette"
 author: "Edward Wallace"
-date: "2 Feb 2019"
-output:
-  html_document:
-    toc: true
-    toc_depth: 2
+date: "Feb 2019"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Calibration}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
 ---
 
 
@@ -43,7 +44,7 @@ These probes have sensible standard curves, amplification curves, melt curves. I
 
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -291,7 +291,7 @@ ggplot(data=platesmelt %>%
 ```{r plotamp_Rep1,dependson="load_amp",fig.width=12,fig.height=6}
 ggplot(data=platesamp %>% 
            filter(TechRep==1,BiolRep==1),
-       aes(x=Cycle,y=Fluor,linetype=Type)) + 
+       aes(x=Cycle,y=Signal,linetype=Type)) + 
     facet_grid(Condition~Probe) + 
     geom_line() +
     scale_linetype_manual(values=c("-RT"="dashed","+RT"="solid")) +
@@ -302,7 +302,7 @@ ggplot(data=platesamp %>%
 ```{r plotamp_Rep2,dependson="load_amp",fig.width=12,fig.height=6}
 ggplot(data=platesamp %>% 
            filter(TechRep==1,BiolRep==2),
-       aes(x=Cycle,y=Fluor,linetype=Type)) + 
+       aes(x=Cycle,y=Signal,linetype=Type)) + 
     facet_grid(Condition~Probe) + 
     geom_line() +
     scale_linetype_manual(values=c("-RT"="dashed","+RT"="solid")) +

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -2,10 +2,11 @@
 title: "Multifactorial multi-plate qPCR analysis"
 author: "Edward Wallace"
 date: "June 2018"
-output:
-  html_document:
-    toc: true
-    toc_depth: 2
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Multifactorial}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
 ---
 
 # Plan
@@ -34,7 +35,7 @@ Test 6 conditions. That's 3 transcriptional inhibitors (no drug control, 150ug/m
 ```{r setup,warning=FALSE,message=FALSE,echo=FALSE}
 
 ## knitr options for report generation
-knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=FALSE,cache=FALSE,
+knitr::opts_chunk$set(warning=FALSE,message=FALSE,echo=TRUE,cache=FALSE,
                       results="show")
 library(tidyverse)
 library(cowplot)


### PR DESCRIPTION
Brings back @DimmestP's fixes from #8 (that we reverted), merged with the improved documentation from #14.

Package passes `R CMD Check`, and installs with functional vignettes by `devtools::install_github("ewallace/tidyqpcr",ref="fix-vignettes-again",build_vignettes = TRUE,force=TRUE)`.