### PR TITLE
Remove cowplot and full-tidyverse dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Suggests:
     knitr,
     rmarkdown,
     tidyverse,
-    cowplot,
     testthat,
     covr
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
 Suggests: 
     knitr,
     rmarkdown,
-    tidyverse,
     testthat,
     covr
 VignetteBuilder: knitr

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Primers and probes calibration vignette"
 author: "Edward Wallace"
-date: "Feb 2019"
+date: "April 2022"
 output: 
   rmarkdown::html_vignette:
     toc: true
@@ -45,7 +45,9 @@ knitr::opts_chunk$set(
 )
 
 # Load packages
-library(tidyverse)
+library(tidyr)
+library(ggplot2)
+library(dplyr)
 library(tidyqpcr)
 
 # set default theme for graphics

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -46,17 +46,13 @@ knitr::opts_chunk$set(
 
 # Load packages
 library(tidyverse)
-library(cowplot)
 library(tidyqpcr)
 
 # set default theme for graphics
-theme_set(theme_cowplot(font_size = 11) %+replace%
+theme_set(theme_bw(base_size = 11) %+replace%
   theme(
-    panel.border = element_rect(
-      colour = "grey50",
-      linetype = "solid", size = 0.5
-    ),
-    strip.background = element_blank()
+    strip.background = element_blank(),
+    panel.grid = element_blank()
   ))
 ```
 
@@ -193,7 +189,6 @@ ggplot(data = plates) +
     title = "All reps, unnormalized"
   ) +
   facet_wrap(~biol_rep) +
-  panel_border() +
   scale_y_continuous(breaks = seq(from = 15, to = 35, by = 5)) + 
   theme(axis.text.x = element_text(angle = 90, vjust = 0.5),
         panel.grid.major.y = element_line(colour="grey80", size = 0.2))

--- a/vignettes/deltacq_96well_vignette.Rmd
+++ b/vignettes/deltacq_96well_vignette.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Delta Cq 96-well plate qPCR analysis example"
 author: "Stuart McKellar and Edward Wallace"
-date: "July 2020"
+date: "April 2022"
 output: 
   rmarkdown::html_vignette:
     toc: true
@@ -37,7 +37,10 @@ knitr::opts_chunk$set(
 )
 
 # Load packages
-library(tidyverse)
+library(tidyr)
+library(ggplot2)
+library(dplyr)
+library(readr)
 library(tidyqpcr)
 
 # set default theme for graphics

--- a/vignettes/deltacq_96well_vignette.Rmd
+++ b/vignettes/deltacq_96well_vignette.Rmd
@@ -38,17 +38,13 @@ knitr::opts_chunk$set(
 
 # Load packages
 library(tidyverse)
-library(cowplot)
 library(tidyqpcr)
 
 # set default theme for graphics
-theme_set(theme_cowplot(font_size = 11) %+replace%
+theme_set(theme_bw(base_size = 11) %+replace%
   theme(
-    panel.border = element_rect(
-      colour = "grey50",
-      linetype = "solid", size = 0.5
-    ),
-    strip.background = element_blank()
+    strip.background = element_blank(),
+    panel.grid = element_blank()
   ))
 ```
 

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -46,16 +46,11 @@ knitr::opts_chunk$set(
 
 # Load packages
 library(tidyverse)
-library(cowplot)
 library(tidyqpcr)
 
 # set default theme for graphics
-theme_set(theme_cowplot(font_size = 11) %+replace%
+theme_set(theme_bw(base_size = 11) %+replace%
   theme(
-    panel.border = element_rect(
-      colour = "grey50",
-      linetype = "solid", size = 0.5
-    ),
     strip.background = element_blank()
   ))
 ```
@@ -232,13 +227,7 @@ ggplot(data = platesmed) +
   ) +
   scale_shape_manual(values = c(15:18, 5:6)) +
   scale_y_log10nice("mRNA relative detection") +
-  theme(
-    axis.text.x = element_text(angle = 90, vjust = 0.5),
-    panel.border = element_rect(
-      fill = NA, linetype = 1,
-      colour = "grey50", size = 0.5
-    )
-  )
+  theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
 ```
 
 ### Faceted by drug treatment
@@ -253,13 +242,7 @@ ggplot(data = platesmed) +
   facet_wrap(~drug, ncol = 3) +
   scale_colour_manual(values = c("-" = "grey50", "+" = "red")) +
   scale_y_log10nice("mRNA relative detection") +
-  theme(
-    axis.text.x = element_text(angle = 90, vjust = 0.5),
-    panel.border = element_rect(
-      fill = NA, linetype = 1,
-      colour = "grey50", size = 0.5
-    )
-  )
+  theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
 ```
 
 ### Faceted by heat shock condition
@@ -273,13 +256,7 @@ ggplot(data = platesmed) +
   ) +
   facet_wrap(~heat, ncol = 3) +
   scale_y_log10nice("mRNA relative detection") +
-  theme(
-    axis.text.x = element_text(angle = 90, vjust = 0.5),
-    panel.border = element_rect(
-      fill = NA, linetype = 1,
-      colour = "grey50", size = 0.5
-    )
-  )
+  theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
 ```
 
 
@@ -332,7 +309,7 @@ ggplot(
   scale_x_continuous(breaks = seq(60, 100, 10),
                      minor_breaks = seq(60, 100, 5)) +
   labs(title = "Melt curves, biol. rep. 1, tech. rep. 1") +
-  panel_border()
+  theme(panel.grid = element_blank())
 ```
 
 ## Melt Curves, biol_rep 2
@@ -349,7 +326,7 @@ ggplot(
   scale_x_continuous(breaks = seq(60, 100, 10),
                      minor_breaks = seq(60, 100, 5)) +
   labs(title = "Melt curves, biol. rep. 2, tech. rep. 1") +
-  panel_border()
+  theme(panel.grid = element_blank())
 ```
 
 
@@ -366,7 +343,7 @@ ggplot(
   scale_linetype_manual(values = c("-RT" = "dashed", "+RT" = "solid")) +
   expand_limits(y = 0) +
   labs(title = "Amp. curves, biol. rep. 1, tech. rep. 1") +
-  panel_border()
+  theme(panel.grid = element_blank())
 ```
 
 ```{r plotamp_rep2,dependson="load_amp",fig.width=12,fig.height=6}
@@ -380,5 +357,5 @@ ggplot(
   scale_linetype_manual(values = c("-RT" = "dashed", "+RT" = "solid")) +
   expand_limits(y = 0) +
   labs(title = "Amp. curves, biol. rep. 2, tech. rep. 1") +
-  panel_border()
+  theme(panel.grid = element_blank())
 ```

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Multifactorial multi-plate qPCR analysis example"
 author: "Edward Wallace"
-date: "June 2018"
+date: "April 2022"
 output: 
   rmarkdown::html_vignette:
     toc: true
@@ -45,7 +45,9 @@ knitr::opts_chunk$set(
 )
 
 # Load packages
-library(tidyverse)
+library(tidyr)
+library(ggplot2)
+library(dplyr)
 library(tidyqpcr)
 
 # set default theme for graphics

--- a/vignettes/platesetup_vignette.Rmd
+++ b/vignettes/platesetup_vignette.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Introduction to designing an experiment and setting up a plate plan in tidyqpcr"
 author: "Edward Wallace"
-date: "April 2020"
+date: "April 2022"
 output: 
   rmarkdown::html_vignette:
     toc: true
@@ -45,7 +45,9 @@ knitr::opts_chunk$set(
 )
 
 # Load packages
-library(tidyverse)
+library(tidyr)
+library(ggplot2)
+library(dplyr)
 library(tidyqpcr)
 ```
 


### PR DESCRIPTION
- remove cowplot dependency, fixes #158
- vignettes load tidyr, dplyr, ggplot2 specifically, not the whole tidyverse
- tidyverse and no longer suggested in DESCRIPTION