### PR TITLE
Rethink coerce_factors, fixes 163

### DIFF
--- a/R/calculate_deltacq.R
+++ b/R/calculate_deltacq.R
@@ -55,12 +55,16 @@ calculate_normvalue <- function(value_df,
                       value_name = "value",
                       id_name = "id",
                       norm_function = median) {
+    
+    assertthat::assert_that(assertthat::has_name(value_df, value_name))
+    assertthat::assert_that(assertthat::has_name(value_df, id_name))
+    
     # make subset of value_df where gene is one or more ref_ids
     value_to_norm_by <- dplyr::filter(value_df,
                              .data[[id_name]] %in% ref_ids) %>%
         dplyr::pull({{value_name}}) %>%
         norm_function(na.rm = TRUE)
-    #
+    
     # assign summary (median) value to value_df$value_to_norm_by
     dplyr::mutate(value_df, value_to_norm_by = value_to_norm_by)
 }
@@ -124,6 +128,11 @@ calculate_normvalue <- function(value_df,
 calculate_deltacq_bysampleid <- function(cq_df,
                                          ref_target_ids,
                                          norm_function = median) {
+    
+    assertthat::assert_that(assertthat::has_name(cq_df, "target_id"))
+    assertthat::assert_that(assertthat::has_name(cq_df, "sample_id"))
+    assertthat::assert_that(assertthat::has_name(cq_df, "cq"))
+    
     cq_df %>%
         dplyr::group_by(.data$sample_id) %>%
         dplyr::do(calculate_normvalue(.data,
@@ -210,7 +219,13 @@ calculate_deltadeltacq_bytargetid <- function(deltacq_df,
                                          ref_sample_ids,
                                          norm_function = median,
                                          ddcq_positive = TRUE) {
+    
+    assertthat::assert_that(assertthat::has_name(deltacq_df, "target_id"))
+    assertthat::assert_that(assertthat::has_name(deltacq_df, "sample_id"))
+    assertthat::assert_that(assertthat::has_name(deltacq_df, "delta_cq"))
+    
     ddcq_factor <- (-1) ^ ddcq_positive
+    
     deltacq_df %>%
         dplyr::group_by(.data$target_id) %>%
         dplyr::do(calculate_normvalue(.data,

--- a/R/calculate_deltacq.R
+++ b/R/calculate_deltacq.R
@@ -56,8 +56,9 @@ calculate_normvalue <- function(value_df,
                       id_name = "id",
                       norm_function = median) {
     
-    assertthat::assert_that(assertthat::has_name(value_df, value_name))
-    assertthat::assert_that(assertthat::has_name(value_df, id_name))
+    assertthat::assert_that(
+        assertthat::has_name(value_df, 
+                             c(value_name,id_name)))
     
     # make subset of value_df where gene is one or more ref_ids
     value_to_norm_by <- dplyr::filter(value_df,
@@ -129,9 +130,9 @@ calculate_deltacq_bysampleid <- function(cq_df,
                                          ref_target_ids,
                                          norm_function = median) {
     
-    assertthat::assert_that(assertthat::has_name(cq_df, "target_id"))
-    assertthat::assert_that(assertthat::has_name(cq_df, "sample_id"))
-    assertthat::assert_that(assertthat::has_name(cq_df, "cq"))
+    assertthat::assert_that(
+        assertthat::has_name(cq_df, 
+                             c("target_id", "sample_id","cq")))
     
     cq_df %>%
         dplyr::group_by(.data$sample_id) %>%
@@ -220,9 +221,9 @@ calculate_deltadeltacq_bytargetid <- function(deltacq_df,
                                          norm_function = median,
                                          ddcq_positive = TRUE) {
     
-    assertthat::assert_that(assertthat::has_name(deltacq_df, "target_id"))
-    assertthat::assert_that(assertthat::has_name(deltacq_df, "sample_id"))
-    assertthat::assert_that(assertthat::has_name(deltacq_df, "delta_cq"))
+    assertthat::assert_that(
+        assertthat::has_name(deltacq_df, 
+                             c("target_id", "sample_id","delta_cq")))
     
     ddcq_factor <- (-1) ^ ddcq_positive
     

--- a/R/calculate_efficiency.R
+++ b/R/calculate_efficiency.R
@@ -121,7 +121,10 @@ calculate_efficiency <- function(cq_df_1, formula = cq ~ log2(dilution) + biol_r
 calculate_efficiency_bytargetid <- function(cq_df,
                            formula = cq ~ log2(dilution) + biol_rep,
                            use_prep_types="+RT") {
+    assertthat::assert_that(assertthat::has_name(cq_df, "target_id"))
+    
     if (!is.na(use_prep_types)) {
+        assertthat::assert_that(assertthat::has_name(cq_df, "prep_type"))
         cq_df <- dplyr::filter(cq_df, .data$prep_type %in% use_prep_types)
     }
     cq_df %>%

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -159,6 +159,7 @@ create_colkey_6_in_24 <- function(...) {
 #'
 #' @export
 #' @importFrom tibble tibble
+#' @importFrom forcats as_factor
 #'
 create_colkey_4diln_2ctrl_in_24 <- function(
                      dilution      = c(5 ^ (0:-3), 1, 1),
@@ -172,10 +173,9 @@ create_colkey_4diln_2ctrl_in_24 <- function(
     tibble(well_col = factor(1:24),
            dilution = rep(dilution, 4),
            dilution_nice = rep(dilution_nice, 4),
-           prep_type = factor(rep(prep_type, 4),
-                         levels = c("+RT", "-RT", "NT")),
-           biol_rep = factor(biol_rep),
-           tech_rep = factor(tech_rep)
+           prep_type = as_factor(rep(prep_type, 4)),
+           biol_rep = as_factor(biol_rep),
+           tech_rep = as_factor(tech_rep)
     )
 }
 
@@ -200,6 +200,7 @@ create_colkey_4diln_2ctrl_in_24 <- function(
 #'
 #' @export
 #' @importFrom tibble tibble
+#' @importFrom forcats as_factor
 #'
 create_colkey_6diln_2ctrl_in_24 <- function(
                      dilution = c(5 ^ (0:-5), 1, 1),
@@ -211,9 +212,8 @@ create_colkey_6diln_2ctrl_in_24 <- function(
     tibble(well_col = factor(1:24),
            dilution = rep(dilution, 3),
            dilution_nice = rep(dilution_nice, 3),
-           prep_type = factor(rep(prep_type, 3),
-                         levels = c("+RT", "-RT", "NT")),
-           tech_rep = factor(tech_rep))
+           prep_type = as_factor(rep(prep_type, 3)),
+           tech_rep = as_factor(tech_rep))
 }
 
 #' Create a 4-value, 16-row key for plates
@@ -233,14 +233,14 @@ create_colkey_6diln_2ctrl_in_24 <- function(
 #'
 #' @export
 #' @importFrom tibble tibble as_tibble
+#' @importFrom forcats as_factor
 #' @importFrom tidyr %>%
 #'
 create_rowkey_4_in_16 <- function(...) {
     rowkey <- tibble(well_row = factor(LETTERS[1:16]),
-                     prep_type = factor(c(rep("+RT", 12), rep("-RT", 4)),
-                                   levels = c("+RT", "-RT")),
-                     tech_rep = factor(rep(c(1, 2, 3, 1), each = 4),
-                                      levels = 1:3))
+                     prep_type = as_factor(c(rep("+RT", 12), rep("-RT", 4))),
+                     tech_rep = as_factor(rep(c(1, 2, 3, 1), each = 4))
+    )
     if (!missing(...)) {
         pieces4 <- list(...) %>% as_tibble()
         stopifnot(nrow(pieces4) == 4)
@@ -334,6 +334,7 @@ create_rowkey_8_in_16_plain <- function(...) {
 #' @export
 #'
 #' @importFrom rlang .data
+#' @importFrom forcats as_factor
 #'
 label_plate_rowcol <- function(plate,
                                rowkey = NULL,
@@ -346,13 +347,13 @@ label_plate_rowcol <- function(plate,
     if (!is.factor(plate$well_col) & coercefactors){
         warning("plate$well_col is not a factor. Automatically generating plate$well_col factor levels. May lead to incorrect plate plans.")
         plate <- plate %>%
-            mutate(well_col = factor(well_col))
+            dplyr::mutate(well_col = as_factor(well_col))
     }
     
     if (!is.factor(plate$well_row) & coercefactors){
         warning("plate$well_row is not a factor. Automatically generating plate$well_row factor levels. May lead to incorrect plate plans.")
         plate <- plate %>%
-            mutate(well_row = factor(well_row))
+            dplyr::mutate(well_row = as_factor(well_row))
     }
     
     if (!is.null(colkey)) {
@@ -487,7 +488,6 @@ display_plate <- function(plate) {
 #' @family plate creation functions
 #'
 #' @export
-#' @importFrom forcats as_factor
 #' @importFrom rlang .data
 #'
 display_plate_qpcr <- function(plate) {

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -314,8 +314,8 @@ create_rowkey_8_in_16_plain <- function(...) {
 #'   messages the user.
 #'
 #'   Other tidyqpcr functions require plate plans to contain variables
-#'   sample_id, target_id, and prep_type, so `label_plate_rowcol` will warn if
-#'   any of these are missing. This is a warning, not an error, because these
+#'   sample_id, target_id, and prep_type, so `label_plate_rowcol` will message
+#'   if any of these are missing. This is a message, not an error, because these
 #'   variables can be added by users later.
 #'
 #' @examples
@@ -361,15 +361,15 @@ label_plate_rowcol <- function(plate,
         }
         plate <- dplyr::left_join(plate, rowkey, by = "well_row")
     }
-    # check that plate contains sample_id, target_id, prep_type, warn if not
+    # check that plate contains sample_id, target_id, prep_type
     if (! "sample_id" %in% names(plate)) {
-        warning("plate does not contain variable sample_id")
+        message("plate does not contain variable sample_id")
     }
     if (! "target_id" %in% names(plate)) {
-        warning("plate does not have variable target_id")
+        message("plate does not have variable target_id")
     }
     if (! "prep_type" %in% names(plate)) {
-        warning("plate does not have variable prep_type")
+        message("plate does not have variable prep_type")
     }
     return(dplyr::arrange(plate, .data$well_row, .data$well_col))
 }
@@ -403,6 +403,9 @@ label_plate_rowcol <- function(plate,
 #' @importFrom rlang .data
 #'
 display_plate <- function(plate) {
+    assertthat::assert_that(assertthat::has_name(plate, "well_row"))
+    assertthat::assert_that(assertthat::has_name(plate, "well_col"))
+    
     rowlevels <- 
         dplyr::pull(plate, .data$well_row) %>%
         as_factor() %>%
@@ -467,6 +470,9 @@ display_plate <- function(plate) {
 #' @importFrom rlang .data
 #'
 display_plate_qpcr <- function(plate) {
+    assertthat::assert_that(assertthat::has_name(plate, "target_id"))
+    assertthat::assert_that(assertthat::has_name(plate, "sample_id"))
+    assertthat::assert_that(assertthat::has_name(plate, "prep_type"))
     
     display_plate(plate) +
         ggplot2::geom_tile(ggplot2::aes(fill = .data$target_id), 

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -130,7 +130,8 @@ create_colkey_6_in_24 <- function(...) {
                      )
     if (!missing(...)) {
         pieces6 <- list(...) %>% as_tibble()
-        stopifnot(nrow(pieces6) == 6)
+        assertthat::assert_that(nrow(pieces6) == 6, 
+                                msg = "Some input data is not of length 6")
         pieces24 <- dplyr::bind_rows(pieces6, pieces6, pieces6, pieces6)
         colkey <- dplyr::bind_cols(colkey, pieces24)
     }
@@ -243,7 +244,8 @@ create_rowkey_4_in_16 <- function(...) {
     )
     if (!missing(...)) {
         pieces4 <- list(...) %>% as_tibble()
-        stopifnot(nrow(pieces4) == 4)
+        assertthat::assert_that(nrow(pieces4) == 4, 
+                                msg = "Some input data is not of length 4")
         pieces16 <- dplyr::bind_rows(pieces4, pieces4, pieces4, pieces4)
         rowkey <- dplyr::bind_cols(rowkey, pieces16)
     }
@@ -274,7 +276,8 @@ create_rowkey_8_in_16_plain <- function(...) {
     rowkey <- tibble(well_row = factor(LETTERS[1:16]))
     if (!missing(...)) {
         pieces8 <- list(...) %>% as_tibble()
-        stopifnot(nrow(pieces8) == 8)
+        assertthat::assert_that(nrow(pieces8) == 8, 
+                                msg = "Some input data is not of length 8")
         pieces16 <- dplyr::bind_rows(pieces8, pieces8)
         rowkey <- dplyr::bind_cols(rowkey, pieces16)
     }
@@ -340,9 +343,9 @@ label_plate_rowcol <- function(plate,
                                rowkey = NULL,
                                colkey = NULL,
                                coercefactors = TRUE) {
-    if (! "well_col" %in% names(plate) | ! "well_row" %in% names(plate)){
-        stop("plate must contain well_row and well_col variables")
-    }
+    assertthat::assert_that(
+        assertthat::has_name(plate, 
+                             c("well_row","well_col")))
     
     if (!is.factor(plate$well_col) & coercefactors){
         warning("plate$well_col is not a factor. Automatically generating plate$well_col factor levels. May lead to incorrect plate plans.")

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -311,7 +311,7 @@ create_rowkey_8_in_16_plain <- function(...) {
 #'   character (1,10,11,...), instead of a factor or integer (1,2,3,...). For
 #'   this reason, the function by default converts well_row in `rowkey`, and
 #'   well_col in `colkey`, to factors, taking factor levels from `plate`, and
-#'   warns the user.
+#'   messages the user.
 #'
 #'   Other tidyqpcr functions require plate plans to contain variables
 #'   sample_id, target_id, and prep_type, so `label_plate_rowcol` will warn if
@@ -338,9 +338,9 @@ label_plate_rowcol <- function(plate,
     if (!is.null(colkey)) {
         assertthat::assert_that(assertthat::has_name(colkey, "well_col"))
         # Note: should this if clause be a freestanding function?
-        # coerce_column_to_factor(df, col, warn=TRUE)?
+        # coerce_column_to_factor(df, col, warn=FALSE)?
         if (!is.factor(colkey$well_col) & coercefactors) {
-            warning("coercing well_col to a factor with levels from plate$well_col")
+            message("coercing well_col to a factor with levels from plate$well_col")
             colkey <- dplyr::mutate(
                 colkey,
                 well_col = factor(.data$well_col,
@@ -352,7 +352,7 @@ label_plate_rowcol <- function(plate,
     if (!is.null(rowkey)) {
         assertthat::assert_that(assertthat::has_name(rowkey, "well_row"))
         if (!is.factor(rowkey$well_row) & coercefactors) {
-            warning("coercing well_row to a factor with levels from plate$well_row")
+            message("coercing well_row to a factor with levels from plate$well_row")
             rowkey <- dplyr::mutate(
                 rowkey,
                 well_row = factor(.data$well_row,

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -403,8 +403,9 @@ label_plate_rowcol <- function(plate,
 #' @importFrom rlang .data
 #'
 display_plate <- function(plate) {
-    assertthat::assert_that(assertthat::has_name(plate, "well_row"))
-    assertthat::assert_that(assertthat::has_name(plate, "well_col"))
+    assertthat::assert_that(
+        assertthat::has_name(plate, 
+                             c("well_row","well_col")))
     
     rowlevels <- 
         dplyr::pull(plate, .data$well_row) %>%
@@ -470,9 +471,11 @@ display_plate <- function(plate) {
 #' @importFrom rlang .data
 #'
 display_plate_qpcr <- function(plate) {
-    assertthat::assert_that(assertthat::has_name(plate, "target_id"))
-    assertthat::assert_that(assertthat::has_name(plate, "sample_id"))
-    assertthat::assert_that(assertthat::has_name(plate, "prep_type"))
+    assertthat::assert_that(
+        assertthat::has_name(plate, 
+                             c("target_id",
+                               "sample_id",
+                               "prep_type")))
     
     display_plate(plate) +
         ggplot2::geom_tile(ggplot2::aes(fill = .data$target_id), 

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -122,11 +122,9 @@ create_blank_plate_1536well <- function(
 #' @importFrom tidyr %>%
 #'
 create_colkey_6_in_24 <- function(...) {
-    colkey <- tibble(well_col   = factor(1:24),
-                     prep_type    = c(rep("+RT", 18), rep("-RT", 6)) %>%
-                         factor(levels = c("+RT", "-RT")),
-                     tech_rep = rep(c(1, 2, 3, 1), each = 6) %>%
-                         factor(levels = 1:3)
+    colkey <- tibble(well_col  = factor(1:24),
+                     prep_type = as_factor(c(rep("+RT", 18), rep("-RT", 6))),
+                     tech_rep  = as_factor(rep(c(1, 2, 3, 1), each = 6))
                      )
     if (!missing(...)) {
         pieces6 <- list(...) %>% as_tibble()
@@ -165,8 +163,8 @@ create_colkey_6_in_24 <- function(...) {
 create_colkey_4diln_2ctrl_in_24 <- function(
                      dilution      = c(5 ^ (0:-3), 1, 1),
                      dilution_nice = c("1x", "5x", "25x", "125x", "-RT", "NT"),
-                     prep_type         = c(rep("+RT", 4), "-RT", "NT"),
-                     biol_rep       = rep(c("A", "B"), each = 12,
+                     prep_type     = c(rep("+RT", 4), "-RT", "NT"),
+                     biol_rep      = rep(c("A", "B"), each = 12,
                                         length.out = 24),
                      tech_rep      = rep(1:2, each = 6,
                                         length.out = 24)

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -312,6 +312,10 @@ create_rowkey_8_in_16_plain <- function(...) {
 #'   this reason, the function by default converts well_row in `rowkey`, and
 #'   well_col in `colkey`, to factors, taking factor levels from `plate`, and
 #'   messages the user.
+#'   
+#'   If `plate$well_col` or `plate$well_row` are not factors and coercefactors = TRUE 
+#'   label_plate_rowcol will automatically convert them to factors, but will output a 
+#'   warning telling users this may lead to unexpected behaviour. 
 #'
 #'   Other tidyqpcr functions require plate plans to contain variables
 #'   sample_id, target_id, and prep_type, so `label_plate_rowcol` will message
@@ -335,6 +339,22 @@ label_plate_rowcol <- function(plate,
                                rowkey = NULL,
                                colkey = NULL,
                                coercefactors = TRUE) {
+    if (! "well_col" %in% names(plate) | ! "well_row" %in% names(plate)){
+        stop("plate must contain well_row and well_col variables")
+    }
+    
+    if (!is.factor(plate$well_col) & coercefactors){
+        warning("plate$well_col is not a factor. Automatically generating plate$well_col factor levels. May lead to incorrect plate plans.")
+        plate <- plate %>%
+            mutate(well_col = factor(well_col))
+    }
+    
+    if (!is.factor(plate$well_row) & coercefactors){
+        warning("plate$well_row is not a factor. Automatically generating plate$well_row factor levels. May lead to incorrect plate plans.")
+        plate <- plate %>%
+            mutate(well_row = factor(well_row))
+    }
+    
     if (!is.null(colkey)) {
         assertthat::assert_that(assertthat::has_name(colkey, "well_col"))
         # Note: should this if clause be a freestanding function?

--- a/R/plate_functions.R
+++ b/R/plate_functions.R
@@ -348,13 +348,13 @@ label_plate_rowcol <- function(plate,
     if (!is.factor(plate$well_col) & coercefactors){
         warning("plate$well_col is not a factor. Automatically generating plate$well_col factor levels. May lead to incorrect plate plans.")
         plate <- plate %>%
-            dplyr::mutate(well_col = as_factor(well_col))
+            dplyr::mutate(well_col = as_factor(.data$well_col))
     }
     
     if (!is.factor(plate$well_row) & coercefactors){
         warning("plate$well_row is not a factor. Automatically generating plate$well_row factor levels. May lead to incorrect plate plans.")
         plate <- plate %>%
-            dplyr::mutate(well_row = as_factor(well_row))
+            dplyr::mutate(well_row = as_factor(.data$well_row))
     }
     
     if (!is.null(colkey)) {

--- a/README.md
+++ b/README.md
@@ -116,20 +116,16 @@ Individual R functions are also documented, use R's standard help system after l
 A basic use case for designing a 12 well plate is given below, see [IntroDesignPlatesetup](https://ewallace.github.io/tidyqpcr/articles/platesetup_vignette.html) for more details.
 
 ```
-target_id_levels <- c("ACT1", "BFG2", "CDC19", "DED1")
-
 rowkey4 <- tibble(
   well_row = LETTERS[1:4],
-  target_id = target_id_levels
+  target_id = c("ACT1", "BFG2", "CDC19", "DED1")
 )
 
-sample_id_levels <- c("rep1", "rep2", "rep3")
-prep_type_levels <- "+RT"
 
 colkey3 <- tibble(
   well_col = 1:3,
-  sample_id = sample_id_levels,
-  prep_type = prep_type_levels
+  sample_id = c("rep1", "rep2", "rep3"),
+  prep_type = "+RT"
 )
 
 create_blank_plate(well_row = LETTERS[1:4], well_col = 1:3)

--- a/man/display_plate_qpcr.Rd
+++ b/man/display_plate_qpcr.Rd
@@ -39,7 +39,9 @@ full_plate <- label_plate_rowcol(create_blank_plate(),
                                                                             "T_5", "T_6",
                                                                             "T_7", "T_8")), 
                                   create_colkey_6diln_2ctrl_in_24() \%>\% 
-                                      dplyr::mutate(sample_id = paste0(dilution_nice, "_", tech_rep)))
+                                      dplyr::mutate(sample_id = paste0(dilution_nice,
+                                                                       "_",
+                                                                       tech_rep)))
 
 # display full plate
 display_plate_qpcr(full_plate)

--- a/man/label_plate_rowcol.Rd
+++ b/man/label_plate_rowcol.Rd
@@ -33,7 +33,7 @@ tibble (data frame) with variables well_row, well_col, well, and
   character (1,10,11,...), instead of a factor or integer (1,2,3,...). For
   this reason, the function by default converts well_row in `rowkey`, and
   well_col in `colkey`, to factors, taking factor levels from `plate`, and
-  warns the user.
+  messages the user.
 
   Other tidyqpcr functions require plate plans to contain variables
   sample_id, target_id, and prep_type, so `label_plate_rowcol` will warn if

--- a/man/label_plate_rowcol.Rd
+++ b/man/label_plate_rowcol.Rd
@@ -34,6 +34,10 @@ tibble (data frame) with variables well_row, well_col, well, and
   this reason, the function by default converts well_row in `rowkey`, and
   well_col in `colkey`, to factors, taking factor levels from `plate`, and
   messages the user.
+  
+  If `plate$well_col` or `plate$well_row` are not factors and coercefactors = TRUE 
+  label_plate_rowcol will automatically convert them to factors, but will output a 
+  warning telling users this may lead to unexpected behaviour. 
 
   Other tidyqpcr functions require plate plans to contain variables
   sample_id, target_id, and prep_type, so `label_plate_rowcol` will message

--- a/man/label_plate_rowcol.Rd
+++ b/man/label_plate_rowcol.Rd
@@ -36,8 +36,8 @@ tibble (data frame) with variables well_row, well_col, well, and
   messages the user.
 
   Other tidyqpcr functions require plate plans to contain variables
-  sample_id, target_id, and prep_type, so `label_plate_rowcol` will warn if
-  any of these are missing. This is a warning, not an error, because these
+  sample_id, target_id, and prep_type, so `label_plate_rowcol` will message
+  if any of these are missing. This is a message, not an error, because these
   variables can be added by users later.
 }
 \description{


### PR DESCRIPTION
Rethinks coerce_factors, fixes #163
- replaces `warning` by `message` when `coerce_factors` is used for `well_col` and `well_row`
- replaces `warning` by `message` for `target_id` and `sample_id` in `label_plate_rowcol`
- asserts necessary column names in `display_plate` `and calculate_...` functions, fixes #102 

Overall this should make some of the common functions more user-friendly.
