### PR TITLE
Join by 181

### DIFF
--- a/R/amp_melt_curve_functions.R
+++ b/R/amp_melt_curve_functions.R
@@ -50,6 +50,10 @@ debaseline <- function(plateamp, maxcycle = 10) {
             plateamp,
             c("well", "program_no", "cycle", "fluor_raw"))
     )
+    assertthat::assert_that(
+        !assertthat::has_name(plateamp,"fluor_base"),
+        msg = "plateamp contains a variable called fluor_base, which breaks debaseline"
+    )
     baseline <-
         plateamp %>%
         dplyr::group_by(.data$well) %>%

--- a/R/amp_melt_curve_functions.R
+++ b/R/amp_melt_curve_functions.R
@@ -57,7 +57,7 @@ debaseline <- function(plateamp, maxcycle = 10) {
                       .data$cycle <= maxcycle) %>%
         dplyr::summarize(fluor_base = stats::median(.data$fluor_raw))
     plateamp %>%
-        dplyr::left_join(baseline) %>%
+        dplyr::left_join(baseline, by = "well") %>%
         dplyr::mutate(fluor_signal = .data$fluor_raw - .data$fluor_base)
 }
 

--- a/tests/testthat/test-amp_melt_curve_functions.R
+++ b/tests/testthat/test-amp_melt_curve_functions.R
@@ -23,7 +23,10 @@ simulated_debased_amplification_curve_data <- simulated_amplification_curve_data
 ### Test functions give expected output ###
 
 test_that("debaseline functions correctly", {
-    calculated_debased_amplification_curve_data <- debaseline(simulated_amplification_curve_data)
+    calculated_debased_amplification_curve_data <- 
+        simulated_amplification_curve_data %>%
+        dplyr::select(-fluor_base) %>%
+        debaseline()
     
     expect_equal(calculated_debased_amplification_curve_data, simulated_debased_amplification_curve_data)
 })

--- a/vignettes/calibration_vignette.Rmd
+++ b/vignettes/calibration_vignette.Rmd
@@ -146,7 +146,7 @@ file_path_cq <- system.file("extdata",
 plates <- 
   file_path_cq %>%
   read_lightcycler_1colour_cq() %>%
-  right_join(plate1plan)
+  right_join(plate1plan, by = "well")
 ```
 
 
@@ -286,7 +286,7 @@ file_path_raw <- system.file("extdata/Edward_qPCR_Nrd1_calibration_2019-02-02.tx
 plate1curve <- file_path_raw %>%
     read_lightcycler_1colour_raw() %>%
     debaseline() %>%
-    left_join(plate1plan)
+    left_join(plate1plan, by = "well")
 
 # amplification curve is program 2
 platesamp <- plate1curve %>%

--- a/vignettes/deltacq_96well_vignette.Rmd
+++ b/vignettes/deltacq_96well_vignette.Rmd
@@ -117,7 +117,7 @@ We use the tidyverse pipe operator `%>%` to do all these transformations in a ro
 ```{r add_sample_target_data,dependson="load_plates",results="show"}
 plate_cq_data <- 
   create_blank_plate_96well() %>% # row and column labels for each well
-  inner_join(plate_cq_extdata) %>% # join that info to loaded data
+  inner_join(plate_cq_extdata, by = "well") %>% # join that info to loaded data
   # next separate the sample and target information for future data analysis
   separate(sample_info,
            into = c("strain","OD","target_id"), 

--- a/vignettes/multifactor_vignette.Rmd
+++ b/vignettes/multifactor_vignette.Rmd
@@ -126,7 +126,7 @@ file_path_cq_plate1 <- system.file("extdata",
 
 plate1 <- file_path_cq_plate1 %>%
   read_lightcycler_1colour_cq() %>%
-  left_join(plateplan) %>%
+  left_join(plateplan, by = "well") %>%
   mutate(biol_rep = "1", plate = "1")
 
 file_path_cq_plate2 <- system.file("extdata",
@@ -135,7 +135,7 @@ file_path_cq_plate2 <- system.file("extdata",
 
 plate2 <- file_path_cq_plate2 %>%
   read_lightcycler_1colour_cq() %>%
-  left_join(plateplan) %>%
+  left_join(plateplan, by = "well") %>%
   mutate(biol_rep = "2", plate = "2")
 
 # combine data from both plates into a single data frame
@@ -276,7 +276,7 @@ file_path_raw_plate1 <- system.file("extdata/Edward_qPCR_TxnInhibitors_HS_2018-0
 plate1curve <- file_path_raw_plate1 %>%
     read_lightcycler_1colour_raw() %>%
     debaseline() %>%
-    left_join(plateplan) %>%
+    left_join(plateplan, by = "well") %>%
     mutate(biol_rep = 1, plate = 1)
 
 file_path_raw_plate2 <- system.file("extdata/Edward_qPCR_TxnInhibitors_HS_2018-06-15_plate2.txt.gz",
@@ -285,7 +285,7 @@ file_path_raw_plate2 <- system.file("extdata/Edward_qPCR_TxnInhibitors_HS_2018-0
 plate2curve <- file_path_raw_plate2 %>%
     read_lightcycler_1colour_raw() %>%
     debaseline() %>%
-    left_join(plateplan) %>%
+    left_join(plateplan, by = "well") %>%
     mutate(biol_rep = 2, plate = 2)
 
 platesamp <- bind_rows(plate1curve, plate2curve) %>%


### PR DESCRIPTION
Fixes #181 
Explicitly gives "by" argument in calls to `join` functions.

This broke one test for `debaseline()`, which is now fixed and added an assertion that the `plateamp` argument to `debaseline()` does not contain a variable called `fluor_base`